### PR TITLE
Refactor color naming from primary to brand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **BREAKING CHANGE**: Refactored primary color concept to brand color throughout the application
+  - Changed `primaryColor` signal to `brandColor` in palette store
+  - Updated `setPrimaryColor` function to `setBrandColor`
+  - Changed tonal scale naming from `primary-*` to `brand-*` (e.g., `primary-500` → `brand-500`)
+  - Updated all design system exporters (DaisyUI, shadcn/ui, Tailwind V4) to use brand terminology
+  - Updated UI text from "Primary color" to "Brand color" in color input component
+  - Updated palette builder methods to use `brandColor` parameter naming
 - Renamed getAllMethods to generatePalette and updated return type to Palette
 - Updated palette store to use signals and enhanced palette generation logic
 - Renamed PaletteMethod interface to Palette for clarity

--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ src/
 
 ### 🛠️ How It Works
 
-1. **Input a Primary Color:**  
-   Start with your brand or primary color in OKLCH format.
+1. **Input a Brand Color:**  
+   Start with your brand color in OKLCH format.
 
 2. **Generate Palette:**  
    The app builds a full tonal scale, semantic colors, and neutral variants using color science best practices.

--- a/src/features/color-input/components/color-input.tsx
+++ b/src/features/color-input/components/color-input.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo, useRef } from "react";
 import { useSignals } from "@preact/signals-react/runtime";
-import { primaryColor, setPrimaryColor } from "@/features/palette-generation/store/palette-store";
+import { brandColor, setBrandColor } from "@/features/palette-generation/store/palette-store";
 import { effect, signal } from "@preact/signals-react";
 import { ColorMath } from "@/features/palette-generation/lib/color-math";
 import { Card } from "@/features/shared/components/card";
@@ -52,11 +52,11 @@ export default function ColorInput() {
 		return () => clearTimeout(timeoutId);
 	});
 
-	// One-time initialization from current primaryColor
+	// One-time initialization from current brandColor
 	const initRef = useRef(false);
 	if (!initRef.current) {
 		try {
-			const parsed = ColorMath.parseOklch(primaryColor.value);
+			const parsed = ColorMath.parseOklch(brandColor.value);
 			lSignal.value = parsed.l;
 			cSignal.value = parsed.c;
 			hSignal.value = parsed.h;
@@ -72,7 +72,7 @@ export default function ColorInput() {
 	const pushToSignal = (nextL: number, nextC: number, nextH: number) => {
 		const formatted = formatOKLCH(nextL, nextC, nextH);
 		rawSignal.value = formatted;
-		setPrimaryColor(formatted);
+		setBrandColor(formatted);
 	};
 
 	// Real-time palette sync while dragging (throttled to rAF)
@@ -155,7 +155,7 @@ export default function ColorInput() {
 			<div className="space-y-4">
 				<div className="flex items-center justify-between">
 					<div className="space-y-1">
-						<h3 className="text-lg font-semibold">Primary color</h3>
+						<h3 className="text-lg font-semibold">Brand color</h3>
 						<p className="text-muted-foreground text-sm">
 							Type OKLCH or use the sliders. We’ll keep it valid and in sync.
 						</p>

--- a/src/features/design-system-export/lib/daisyui-exporter.ts
+++ b/src/features/design-system-export/lib/daisyui-exporter.ts
@@ -6,7 +6,7 @@ type CssVars = Record<string, string>;
 export class DaisyUIExporter {
 	private static lightVars(method: Palette): CssVars {
 		const { tonalScale, neutralScale, semanticColors, baseScale } = method;
-		const primary500 = tonalScale.find((s) => s.scale === "primary-500");
+		const brand500 = tonalScale.find((s) => s.scale === "brand-500");
 
 		return {
 			"--color-base-50": getBaseColor("base-50", baseScale, "oklch(99.5% 0.001 0)"),
@@ -15,11 +15,11 @@ export class DaisyUIExporter {
 			"--color-base-300": getBaseColor("base-300", baseScale, "oklch(95% 0 0)"),
 			"--color-base-content": getBaseForeground("base-900", baseScale, "oklch(21% 0.006 285.885)"),
 			"--color-primary": normalizeFull(
-				primary500?.color || "oklch(45% 0.24 277.023)",
+				brand500?.color || "oklch(45% 0.24 277.023)",
 				"oklch(45% 0.24 277.023)"
 			),
 			"--color-primary-content": normalizeFull(
-				primary500?.foreground || "oklch(93% 0.034 272.788)",
+				brand500?.foreground || "oklch(93% 0.034 272.788)",
 				"oklch(93% 0.034 272.788)"
 			),
 			"--color-secondary": findAndNormalize(
@@ -35,13 +35,13 @@ export class DaisyUIExporter {
 				"oklch(94% 0.028 342.258)"
 			),
 			"--color-accent": findAndNormalize(
-				"primary-300",
+				"brand-300",
 				tonalScale,
 				neutralScale,
 				"oklch(77% 0.152 181.912)"
 			),
 			"--color-accent-content": findAndNormalize(
-				"primary-900",
+				"brand-900",
 				tonalScale,
 				neutralScale,
 				"oklch(38% 0.063 188.416)"
@@ -91,7 +91,7 @@ export class DaisyUIExporter {
 
 	private static darkVars(method: Palette): CssVars {
 		const { tonalScale, neutralScale, semanticColors, baseScale } = method;
-		const primary500 = tonalScale.find((s) => s.scale === "primary-500");
+		const brand500 = tonalScale.find((s) => s.scale === "brand-500");
 
 		return {
 			"--color-base-50": getBaseColor("base-50", baseScale, "oklch(99.5% 0.001 0)"),
@@ -104,11 +104,11 @@ export class DaisyUIExporter {
 				"oklch(97.807% 0.029 256.847)"
 			),
 			"--color-primary": normalizeFull(
-				primary500?.color || "oklch(58% 0.233 277.117)",
+				brand500?.color || "oklch(58% 0.233 277.117)",
 				"oklch(58% 0.233 277.117)"
 			),
 			"--color-primary-content": normalizeFull(
-				primary500?.foreground || "oklch(96% 0.018 272.314)",
+				brand500?.foreground || "oklch(96% 0.018 272.314)",
 				"oklch(96% 0.018 272.314)"
 			),
 			"--color-secondary": findAndNormalize(
@@ -124,13 +124,13 @@ export class DaisyUIExporter {
 				"oklch(94% 0.028 342.258)"
 			),
 			"--color-accent": findAndNormalize(
-				"primary-300",
+				"brand-300",
 				tonalScale,
 				neutralScale,
 				"oklch(77% 0.152 181.912)"
 			),
 			"--color-accent-content": findAndNormalize(
-				"primary-900",
+				"brand-900",
 				tonalScale,
 				neutralScale,
 				"oklch(38% 0.063 188.416)"

--- a/src/features/design-system-export/lib/palette-utils.ts
+++ b/src/features/design-system-export/lib/palette-utils.ts
@@ -32,13 +32,13 @@ export const findAndNormalize = (
 };
 
 // Generates a set of 5 distinct and vibrant chart colors.
-export const generateChartColors = (primaryHue: number): { light: CssVars; dark: CssVars } => {
+export const generateChartColors = (brandHue: number): { light: CssVars; dark: CssVars } => {
 	const hues = [
-		normalizeHue(primaryHue + 30),
-		normalizeHue(primaryHue + 90),
-		normalizeHue(primaryHue + 180),
-		normalizeHue(primaryHue + 270),
-		normalizeHue(primaryHue - 30),
+		normalizeHue(brandHue + 30),
+		normalizeHue(brandHue + 90),
+		normalizeHue(brandHue + 180),
+		normalizeHue(brandHue + 270),
+		normalizeHue(brandHue - 30),
 	];
 	const lightModePersonality = { l: 70, c: 0.15 };
 	const darkModePersonality = { l: 75, c: 0.2 };

--- a/src/features/design-system-export/lib/shadcn-exporter.ts
+++ b/src/features/design-system-export/lib/shadcn-exporter.ts
@@ -15,7 +15,7 @@ export class ShadcnExporter {
 
 	private static light(method: Palette): CssVars {
 		const { tonalScale, neutralScale, semanticColors, chartScale } = method;
-		const primary = tonalScale.find((s) => s.scale === "primary-600")?.color || tonalScale[6].color;
+		const primary = tonalScale.find((s) => s.scale === "brand-600")?.color || tonalScale[6].color;
 		const primaryFg = neutralScale.find((s) => s.scale === "neutral-50")?.color || "oklch(1 0 0)";
 		const chartVars: CssVars = {};
 		chartScale.forEach((c, i) => {
@@ -58,8 +58,8 @@ export class ShadcnExporter {
 
 	private static dark(method: Palette): CssVars {
 		const { tonalScale, semanticColors, chartScale } = method;
-		const primary = tonalScale.find((s) => s.scale === "primary-500")?.color || tonalScale[5].color;
-		const primaryFg = tonalScale.find((s) => s.scale === "primary-300")?.color || primary;
+		const primary = tonalScale.find((s) => s.scale === "brand-500")?.color || tonalScale[5].color;
+		const primaryFg = tonalScale.find((s) => s.scale === "brand-300")?.color || primary;
 		const chartVars: CssVars = {};
 		chartScale.forEach((c, i) => {
 			chartVars[`--chart-${i + 1}`] = normalizeFull(c.color, c.color);

--- a/src/features/design-system-export/lib/tailwind-v4-exporter.ts
+++ b/src/features/design-system-export/lib/tailwind-v4-exporter.ts
@@ -24,7 +24,7 @@ export class TailwindV4Exporter {
 			);
 		});
 
-		// Primary colors
+		// Brand colors
 		palette.tonalScale.forEach((shade) => {
 			const varName = `--color-${shade.scale}`;
 			vars[varName] = normalizeFull(shade.color, "oklch(0.5 0.2 240)");
@@ -71,18 +71,18 @@ export class TailwindV4Exporter {
   --color-card-foreground: var(--color-base-900-foreground);
   --color-popover: var(--color-base-200);
   --color-popover-foreground: var(--color-base-900-foreground);
-  --color-primary: var(--color-primary-500);
-  --color-primary-foreground: var(--color-primary-500-foreground);
+  --color-primary: var(--color-brand-500);
+  --color-primary-foreground: var(--color-brand-500-foreground);
   --color-secondary: var(--color-neutral-200);
   --color-secondary-foreground: var(--color-neutral-50-foreground);
   --color-muted: var(--color-base-300);
   --color-muted-foreground: var(--color-base-900-foreground);
-  --color-accent: var(--color-primary-300);
-  --color-accent-foreground: var(--color-primary-900-foreground);
+  --color-accent: var(--color-brand-300);
+  --color-accent-foreground: var(--color-brand-900-foreground);
   --color-destructive: var(--color-error);
   --color-border: var(--color-base-400);
   --color-input: var(--color-base-200);
-  --color-ring: var(--color-primary-400);
+  --color-ring: var(--color-brand-400);
   --color-chart-1: var(--color-chart-1);
   --color-chart-2: var(--color-chart-2);
   --color-chart-3: var(--color-chart-3);

--- a/src/features/palette-generation/lib/palette-builder.ts
+++ b/src/features/palette-generation/lib/palette-builder.ts
@@ -134,7 +134,7 @@ export class PaletteBuilder {
 	}
 
 	static buildBaseScale(brandColor: string): ColorShade[] {
-		// Base colors with subtle brand color tint for brand cohesion and lighter scale
+		// Base colors with subtle brand color tint for brand cohesion and consistent theming
 		const { h: baseH } = ColorMath.parseOklch(brandColor);
 
 		return BASE_SCALE_DEFINITIONS.map((shade) => {

--- a/src/features/palette-generation/lib/palette-builder.ts
+++ b/src/features/palette-generation/lib/palette-builder.ts
@@ -12,8 +12,8 @@ import { CHART_HUE_OFFSETS, CHART_TONE } from "@/features/shared/constants/chart
 import { normalizeHue } from "@/features/shared/lib/utils";
 
 export class PaletteBuilder {
-	static buildTonalScale(primaryColor: string): ColorShade[] {
-		const { l: baseL, c: baseC, h: baseH } = ColorMath.parseOklch(primaryColor);
+	static buildTonalScale(brandColor: string): ColorShade[] {
+		const { l: baseL, c: baseC, h: baseH } = ColorMath.parseOklch(brandColor);
 		// Use imported progression constant for stops and scales
 		// PRIMARY_COLORS_LIGHTNESS_PROGRESSION_MAP: [{ scale, l }]
 		const tonalScale: ColorShade[] = PRIMARY_COLORS_LIGHTNESS_PROGRESSION_MAP.map(
@@ -37,7 +37,7 @@ export class PaletteBuilder {
 					4.5
 				);
 				return {
-					scale: `primary-${scale}`,
+					scale: `brand-${scale}`,
 					color: ColorMath.formatOklch(currentL, adjustedChroma, baseH),
 					l: currentL,
 					c: adjustedChroma,
@@ -49,8 +49,8 @@ export class PaletteBuilder {
 		return tonalScale;
 	}
 
-	static buildSemanticColors(primaryColor: string): SemanticColors {
-		const { l: baseL, c: baseC } = ColorMath.parseOklch(primaryColor);
+	static buildSemanticColors(brandColor: string): SemanticColors {
+		const { l: baseL, c: baseC } = ColorMath.parseOklch(brandColor);
 		const targetWeight = ColorMath.calculateWeight(baseL, baseC);
 		const targetEnergy = ColorMath.calculateEnergy(baseL, baseC);
 
@@ -111,10 +111,10 @@ export class PaletteBuilder {
 		return semanticColors as SemanticColors;
 	}
 
-	static buildNeutralScale(primaryColor: string): ColorShade[] {
+	static buildNeutralScale(brandColor: string): ColorShade[] {
 		// Use imported progression constant for stops and scales
 		// NEUTRAL_COLORS_LIGHTNESS_PROGRESSION_MAP: [{ scale, l }]
-		const { h: baseH } = ColorMath.parseOklch(primaryColor);
+		const { h: baseH } = ColorMath.parseOklch(brandColor);
 		// Chroma stops as in make-colors.md
 		const neutralScale: ColorShade[] = NEUTRAL_COLORS_LIGHTNESS_PROGRESSION_MAP.map(
 			({ scale, l }: { scale: string; l: number }, i: number) => {
@@ -133,9 +133,9 @@ export class PaletteBuilder {
 		return neutralScale;
 	}
 
-	static buildBaseScale(primaryColor: string): ColorShade[] {
-		// Base colors with subtle primary color tint for brand cohesion and lighter scale
-		const { h: baseH } = ColorMath.parseOklch(primaryColor);
+	static buildBaseScale(brandColor: string): ColorShade[] {
+		// Base colors with subtle brand color tint for brand cohesion and lighter scale
+		const { h: baseH } = ColorMath.parseOklch(brandColor);
 
 		return BASE_SCALE_DEFINITIONS.map((shade) => {
 			const colorObj = { l: shade.l, c: shade.c, h: shade.c === 0 ? 0 : baseH };
@@ -151,8 +151,8 @@ export class PaletteBuilder {
 		});
 	}
 
-	static buildChartScale(primaryColor: string): ColorShade[] {
-		const { h: baseH } = ColorMath.parseOklch(primaryColor);
+	static buildChartScale(brandColor: string): ColorShade[] {
+		const { h: baseH } = ColorMath.parseOklch(brandColor);
 
 		const chartScale: ColorShade[] = CHART_HUE_OFFSETS.map((offset, index) => {
 			const newHue = normalizeHue(baseH + offset);
@@ -185,21 +185,21 @@ export class PaletteBuilder {
 		return chartScale;
 	}
 
-	static buildPalette(primaryColor: string): Palette {
+	static buildPalette(brandColor: string): Palette {
 		try {
-			const parsed = ColorMath.parseOklch(primaryColor);
+			const parsed = ColorMath.parseOklch(brandColor);
 			if (!ColorMath.validateOklch(parsed)) {
 				throw new Error("Invalid color values.");
 			}
 
 			return {
 				name: `Generated Palette`,
-				description: `A complete color system derived from ${primaryColor}`,
-				baseScale: this.buildBaseScale(primaryColor),
-				tonalScale: this.buildTonalScale(primaryColor),
-				semanticColors: this.buildSemanticColors(primaryColor),
-				neutralScale: this.buildNeutralScale(primaryColor),
-				chartScale: this.buildChartScale(primaryColor),
+				description: `A complete color system derived from ${brandColor}`,
+				baseScale: this.buildBaseScale(brandColor),
+				tonalScale: this.buildTonalScale(brandColor),
+				semanticColors: this.buildSemanticColors(brandColor),
+				neutralScale: this.buildNeutralScale(brandColor),
+				chartScale: this.buildChartScale(brandColor),
 			};
 		} catch (error) {
 			console.error("Error building palette:", error);
@@ -220,17 +220,17 @@ export class PaletteBuilder {
 					{ scale: "base-950", color: "", l: 0, c: 0, h: 0, foreground: "" },
 				],
 				tonalScale: [
-					{ scale: "primary-50", color: "", l: 0, c: 0, h: 0, foreground: "" },
-					{ scale: "primary-100", color: "", l: 0, c: 0, h: 0, foreground: "" },
-					{ scale: "primary-200", color: "", l: 0, c: 0, h: 0, foreground: "" },
-					{ scale: "primary-300", color: "", l: 0, c: 0, h: 0, foreground: "" },
-					{ scale: "primary-400", color: "", l: 0, c: 0, h: 0, foreground: "" },
-					{ scale: "primary-500", color: "", l: 0, c: 0, h: 0, foreground: "" },
-					{ scale: "primary-600", color: "", l: 0, c: 0, h: 0, foreground: "" },
-					{ scale: "primary-700", color: "", l: 0, c: 0, h: 0, foreground: "" },
-					{ scale: "primary-800", color: "", l: 0, c: 0, h: 0, foreground: "" },
-					{ scale: "primary-900", color: "", l: 0, c: 0, h: 0, foreground: "" },
-					{ scale: "primary-950", color: "", l: 0, c: 0, h: 0, foreground: "" },
+					{ scale: "brand-50", color: "", l: 0, c: 0, h: 0, foreground: "" },
+					{ scale: "brand-100", color: "", l: 0, c: 0, h: 0, foreground: "" },
+					{ scale: "brand-200", color: "", l: 0, c: 0, h: 0, foreground: "" },
+					{ scale: "brand-300", color: "", l: 0, c: 0, h: 0, foreground: "" },
+					{ scale: "brand-400", color: "", l: 0, c: 0, h: 0, foreground: "" },
+					{ scale: "brand-500", color: "", l: 0, c: 0, h: 0, foreground: "" },
+					{ scale: "brand-600", color: "", l: 0, c: 0, h: 0, foreground: "" },
+					{ scale: "brand-700", color: "", l: 0, c: 0, h: 0, foreground: "" },
+					{ scale: "brand-800", color: "", l: 0, c: 0, h: 0, foreground: "" },
+					{ scale: "brand-900", color: "", l: 0, c: 0, h: 0, foreground: "" },
+					{ scale: "brand-950", color: "", l: 0, c: 0, h: 0, foreground: "" },
 				],
 				semanticColors: {
 					success: { color: "", foreground: "" },

--- a/src/features/palette-generation/store/palette-store.ts
+++ b/src/features/palette-generation/store/palette-store.ts
@@ -2,10 +2,10 @@ import { signal, computed } from "@preact/signals-react";
 import { PaletteBuilder } from "@/features/palette-generation/lib/palette-builder";
 import type { Palette } from "@/features/shared/types/global";
 
-// Reactive signal for the primary color input
-export const primaryColor = signal<string>("oklch(49.6% 0.272 303.89)");
-export const palette = computed<Palette>(() => PaletteBuilder.buildPalette(primaryColor.value));
+// Reactive signal for the brand color input
+export const brandColor = signal<string>("oklch(49.6% 0.272 303.89)");
+export const palette = computed<Palette>(() => PaletteBuilder.buildPalette(brandColor.value));
 
-export const setPrimaryColor = (value: string) => {
-	primaryColor.value = value;
+export const setBrandColor = (value: string) => {
+	brandColor.value = value;
 };


### PR DESCRIPTION
Update color references throughout the codebase to replace "primary" with "brand" for consistency and clarity in color management. This change enhances the semantic meaning of the color variables used in the application.